### PR TITLE
api proxy for when running into rate limits

### DIFF
--- a/api-proxy/docker-compose.yaml
+++ b/api-proxy/docker-compose.yaml
@@ -1,0 +1,11 @@
+version: '3'
+
+services:
+  openresty:
+    image: openresty/openresty:alpine
+    ports:
+      - "9701:80"
+    volumes:
+      - ./nginx.conf:/usr/local/openresty/nginx/conf/nginx.conf:ro
+    environment:
+      API_KEYS: "comma-separated-list"

--- a/api-proxy/nginx.conf
+++ b/api-proxy/nginx.conf
@@ -1,0 +1,46 @@
+worker_processes 1;  # Set to 1 for a single worker process
+error_log /dev/stderr notice;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+
+    access_log /dev/stdout;
+    lua_package_path "/usr/local/openresty/lualib/?.lua;;";
+
+    init_by_lua_block {
+        local apiKeys = os.getenv("API_KEYS")
+        if not apiKeys then
+            ngx.log(ngx.ERR, "API_KEYS environment variable is not set")
+            return
+        end
+
+        local function split(str, sep)
+            local fields = {}
+            local pattern = string.format("([^%s]+)", sep)
+            str:gsub(pattern, function(c) fields[#fields + 1] = c end)
+            return fields
+        end
+
+        API_KEYS = split(apiKeys, ",")
+        CURRENT_KEY_INDEX = 1
+    }
+
+    server {
+        listen 80;
+
+        location / {
+            access_by_lua_block {
+                ngx.req.clear_header("X-Api-Key")
+                local key = API_KEYS[CURRENT_KEY_INDEX]
+                ngx.req.set_header("X-Api-Key", key)
+                CURRENT_KEY_INDEX = CURRENT_KEY_INDEX % #API_KEYS + 1
+            }
+
+            proxy_pass https://api.anthropic.com;
+            proxy_ssl_server_name on;
+        }
+    }
+}


### PR DESCRIPTION
```bash
docker compose up
```

and then

```bash
ANTHROPIC_API_KEY=anything ANTHROPIC_BASE_URL=http://localhost:9701 poetry run chat_with_tool -d ddn -u http://localhost:3000/v1/sql -H 'x-hasura-role: admin' --llm anthropic
```