### PR TITLE
Pacha chat telemetry

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -718,13 +718,13 @@ test = ["Cython (>=0.29.24,<0.30.0)"]
 
 [[package]]
 name = "httpx"
-version = "0.27.0"
+version = "0.27.2"
 description = "The next generation HTTP client."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "httpx-0.27.0-py3-none-any.whl", hash = "sha256:71d5465162c13681bff01ad59b2cc68dd838ea1f10e51574bac27103f00c91a5"},
-    {file = "httpx-0.27.0.tar.gz", hash = "sha256:a0cb88a46f32dc874e04ee956e4c2764aba2aa228f650b06788ba6bda2962ab5"},
+    {file = "httpx-0.27.2-py3-none-any.whl", hash = "sha256:7bb2708e112d8fdd7829cd4243970f0c223274051cb35ee80c03301ee29a3df0"},
+    {file = "httpx-0.27.2.tar.gz", hash = "sha256:f7c2be1d2f3c3c3160d441802406b206c2b76f5947b11115e6df10c6c65e66c2"},
 ]
 
 [package.dependencies]
@@ -739,6 +739,7 @@ brotli = ["brotli", "brotlicffi"]
 cli = ["click (==8.*)", "pygments (==2.*)", "rich (>=10,<14)"]
 http2 = ["h2 (>=3,<5)"]
 socks = ["socksio (==1.*)"]
+zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "huggingface-hub"
@@ -2420,4 +2421,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "e7fd132d41b682e56bac43d774d232dc7a3a227bc224b7106b503b692230c4b0"
+content-hash = "0592487a7fcba3beac920c4088d401a8ca05b177b445e8b61f59721c8efa284c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ anthropic = "^0.29.0"
 fastapi = "^0.111.1"
 uvicorn = "^0.30.3"
 aiosqlite = "^0.20.0"
+httpx = "^0.27.2"
 
 [tool.poetry.scripts]
 chat_with_tool = "examples.chat_with_tool:main"


### PR DESCRIPTION
3 modes:

`no_data`: User doesn't want any private info in telemetry

`consent_message`: User is okay with private info for a single message in telemetry for improving their system

`consent_full` : User is okay with private info for entire thread in telemetry for improving their system


In no_data mode, we will capture only `feedback_enum` and `feedback_text`


In `consent_message` and `consent_full` mode, we will additionally capture the message context where `message` is the json version of a single message or entire thread depending on the mode. Note that `message` never includes `tool_response` which has actual table fetch data.

