### PR TITLE
add healthz endpoint

### DIFF
--- a/examples/chat_server/server.py
+++ b/examples/chat_server/server.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI, Request, HTTPException, Depends, Body, BackgroundTasks
-from fastapi.responses import JSONResponse, HTMLResponse, RedirectResponse, StreamingResponse
+from fastapi.responses import JSONResponse, HTMLResponse, RedirectResponse, StreamingResponse, PlainTextResponse
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 from typing import Optional, Dict, List, Callable
@@ -305,6 +305,9 @@ async def submit_feedback(thread_id: str, feedback_input: FeedbackInput):
         raise HTTPException(
             status_code=500, detail=f"Error submitting feedback")
 
+@app.get("/healthz",response_class=PlainTextResponse)
+async def health_check():
+    return "OK"
 
 @app.get("/console", response_class=HTMLResponse)
 async def serve_console():

--- a/examples/chat_server/server.py
+++ b/examples/chat_server/server.py
@@ -116,7 +116,7 @@ def init_system_prompt(pacha_tool):
         """
 
 
-PUBLIC_ROUTES = ['/', '/console']
+PUBLIC_ROUTES = ['/', '/console', '/healthz']
 
 
 def init_auth(secret_key):
@@ -307,6 +307,10 @@ async def submit_feedback(thread_id: str, feedback_input: FeedbackInput):
 
 @app.get("/healthz",response_class=PlainTextResponse)
 async def health_check():
+    return "OK"
+
+@app.get("/config-check",response_class=PlainTextResponse)
+async def config_check():
     return "OK"
 
 @app.get("/console", response_class=HTMLResponse)


### PR DESCRIPTION
This PR adds healthz endpoint to pacha, this is primarily for console to show the connection status. 

Qn: considering this is a protected route, do we need to call it different than healthz as healthz usually corresponds to service health in a public manner? 