### PR TITLE
throw error event on exceptions

### DIFF
--- a/examples/chat_server/threads.py
+++ b/examples/chat_server/threads.py
@@ -124,7 +124,7 @@ class Thread:
             yield render_event(ERROR_EVENT, {'error': str(e)})  
         except Exception as e:
             get_logger().error(str(e))
-            yield render_event(ERROR_EVENT, {'error': 'Internal server error, check logs. Try a new thread maybe?'})  
+            yield render_event(ERROR_EVENT, json.dumps({'error': 'Internal server error, check logs. Try a new thread maybe?'}))  
                     
         finally:
             #persist any pending user confirmation requests as canceled or timed out


### PR DESCRIPTION
```
event: error
data: {'error': 'turns must alternate between user and assistant, try a new thread'}
```

Note: Exceptions can make a thread state (sequence of turns) inconsistent and unusable unless we clear inconsistent data and try again. Doing this automatically in the backend is not simple since we have already persisted the turn. Need to think how to handle such cases.