### PR TITLE
Create assistant turn if LlmException occurs

### DIFF
--- a/examples/chat_server/threads.py
+++ b/examples/chat_server/threads.py
@@ -125,12 +125,11 @@ class Thread:
             yield render_event(ERROR_EVENT, json.dumps({'error': str(e)}))
         except LlmException as e:
             get_logger().error(str(e))
-            assistant_turn = AssistantTurn(text="Exception raised")
+            assistant_turn = AssistantTurn(text="Internal error: Could not process")
             await persist_turn(self.db, self.id, assistant_turn, self.chat.artifacts)
             event_data = json.dumps(to_assistant_turn_json(assistant_turn))
             yield render_event(ASSISTANT_RESPONSE_EVENT, event_data) 
-            yield render_event(ERROR_EVENT, json.dumps({'error': 'Error thrown by LLM, check logs. Try a new thread maybe?'}))
-            
+            yield render_event(ERROR_EVENT, json.dumps({'error': 'Error thrown by LLM, check logs and retry. Try a new thread maybe?'}))
         except Exception as e:
             get_logger().error(str(e))
             yield render_event(ERROR_EVENT, json.dumps({'error': 'Internal server error, check logs. Try a new thread maybe?'}))  

--- a/examples/chat_server/threads.py
+++ b/examples/chat_server/threads.py
@@ -123,17 +123,9 @@ class Thread:
         except AssertionError as e:
             get_logger().error(str(e))
             yield render_event(ERROR_EVENT, json.dumps({'error': str(e)}))
-        except LlmException as e:
-            get_logger().error(str(e))
-            assistant_turn = AssistantTurn(text="Internal error: Could not process")
-            await persist_turn(self.db, self.id, assistant_turn, self.chat.artifacts)
-            event_data = json.dumps(to_assistant_turn_json(assistant_turn))
-            yield render_event(ASSISTANT_RESPONSE_EVENT, event_data) 
-            yield render_event(ERROR_EVENT, json.dumps({'error': 'Error thrown by LLM, check logs and retry. Try a new thread maybe?'}))
         except Exception as e:
             get_logger().error(str(e))
             yield render_event(ERROR_EVENT, json.dumps({'error': 'Internal server error, check logs. Try a new thread maybe?'}))  
-                    
         finally:
             #persist any pending user confirmation requests as canceled or timed out
             for confirmation_id, request in self.chat.confirmation_provider.pending.items():

--- a/pacha/sdk/llms/anthropic.py
+++ b/pacha/sdk/llms/anthropic.py
@@ -74,7 +74,8 @@ class Anthropic(Llm):
                     "input_schema": tool.input_schema()
                 } for tool in tools])
         except Exception as e:
-            raise LlmException(str(e))
+            get_logger().error(str(e))
+            return AssistantTurn(text="Exception raised by LLM, check logs and try again?")
         else:
             # print(raw_response.headers)
             response: Message = raw_response.parse()

--- a/pacha/sdk/llms/anthropic.py
+++ b/pacha/sdk/llms/anthropic.py
@@ -2,7 +2,7 @@ from typing import Optional
 import anthropic
 from anthropic.types import Message, MessageParam, ToolParam
 from pacha.sdk.chat import Chat, Turn, ToolCall, UserTurn, AssistantTurn, ToolResponseTurn
-from pacha.sdk.llm import Llm
+from pacha.sdk.llm import Llm, LlmException
 from pacha.sdk.tool import Tool
 from pacha.utils.logging import get_logger
 
@@ -61,29 +61,33 @@ class Anthropic(Llm):
 
         get_logger().debug(f"Anthropic System Prompt: {system_prompt}\nMessages: {str(messages)}")
 
-        raw_response = await self.client.messages.with_raw_response.create(
-            max_tokens=MAX_TOKENS,
-            messages=messages,
-            model=MODEL,
-            temperature=temperature if temperature is not None else anthropic.NotGiven(),
-            system=system_prompt if system_prompt is not None else anthropic.NotGiven(),
-            tools=[{
-                "name": tool.name(),
-                "description": tool.description(),
-                "input_schema": tool.input_schema()
-            } for tool in tools])
-        # print(raw_response.headers)
-        response: Message = raw_response.parse()
+        try:
+            raw_response = await self.client.messages.with_raw_response.create(
+                max_tokens=MAX_TOKENS,
+                messages=messages,
+                model=MODEL,
+                temperature=temperature if temperature is not None else anthropic.NotGiven(),
+                system=system_prompt if system_prompt is not None else anthropic.NotGiven(),
+                tools=[{
+                    "name": tool.name(),
+                    "description": tool.description(),
+                    "input_schema": tool.input_schema()
+                } for tool in tools])
+        except Exception as e:
+            raise LlmException(str(e))
+        else:
+            # print(raw_response.headers)
+            response: Message = raw_response.parse()
 
-        get_logger().info(f"Token Usage: {response.usage}")
+            get_logger().info(f"Token Usage: {response.usage}")
 
-        text = None
-        tool_calls = []
-        for content in response.content:
-            if content.type == "text":
-                assert (text is None)
-                text = content.text
-            elif content.type == "tool_use":
-                tool_calls.append(ToolCall(name=content.name,
-                                  call_id=content.id, input=content.input))
-        return AssistantTurn(text=text, tool_calls=tool_calls)
+            text = None
+            tool_calls = []
+            for content in response.content:
+                if content.type == "text":
+                    assert (text is None)
+                    text = content.text
+                elif content.type == "tool_use":
+                    tool_calls.append(ToolCall(name=content.name,
+                                      call_id=content.id, input=content.input))
+            return AssistantTurn(text=text, tool_calls=tool_calls)

--- a/pacha/sdk/llms/openai.py
+++ b/pacha/sdk/llms/openai.py
@@ -73,24 +73,27 @@ class OpenAI(Llm):
 
         get_logger().debug(f"OpenAI Messages: {str(messages)}")
 
-        response = await self.client.chat.completions.create(
-            messages=messages,
-            model=MODEL,
-            temperature=temperature,
-            tools=[{"type": "function", "function": {
-                "name": tool.name(),
-                "description": tool.description(),
-                "parameters": tool.input_schema()
-            }} for tool in tools]
-        )
+        try:
+            response = await self.client.chat.completions.create(
+                messages=messages,
+                model=MODEL,
+                temperature=temperature,
+                tools=[{"type": "function", "function": {
+                    "name": tool.name(),
+                    "description": tool.description(),
+                    "parameters": tool.input_schema()
+                }} for tool in tools]
+            )
+        except Exception as e:
+            raise LlmException(str(e))
+        else:
+            get_logger().info(f"Token Usage: {response.usage}")
 
-        get_logger().info(f"Token Usage: {response.usage}")
+            message = response.choices[0].message
+            tool_calls = []
+            if message.tool_calls is not None:
+                for tool_call in message.tool_calls:
+                    tool_calls.append(ToolCall(
+                        call_id=tool_call.id, name=tool_call.function.name, input=json.loads(tool_call.function.arguments)))
 
-        message = response.choices[0].message
-        tool_calls = []
-        if message.tool_calls is not None:
-            for tool_call in message.tool_calls:
-                tool_calls.append(ToolCall(
-                    call_id=tool_call.id, name=tool_call.function.name, input=json.loads(tool_call.function.arguments)))
-
-        return AssistantTurn(text=message.content, tool_calls=tool_calls)
+            return AssistantTurn(text=message.content, tool_calls=tool_calls)

--- a/pacha/sdk/llms/openai.py
+++ b/pacha/sdk/llms/openai.py
@@ -85,7 +85,8 @@ class OpenAI(Llm):
                 }} for tool in tools]
             )
         except Exception as e:
-            raise LlmException(str(e))
+            get_logger().error(str(e))
+            return AssistantTurn(text="Exception raised by LLM, check logs and try again?")
         else:
             get_logger().info(f"Token Usage: {response.usage}")
 


### PR DESCRIPTION
We create an artificial assistant turn when a LlmException occurs so that a thread can be followed by a user turn. Without this, the thread state is completely irrecoverable.