### PR TITLE
add docker compose file

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,20 @@
+version: '3.8'
+
+services:
+  pacha:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      - SQL_URL=http://host.docker.internal:3001/v1/sql
+      - PORT=5000
+      - PACHA_LOG_LEVEL=debug
+      - SECRET_KEY=secret
+    volumes:
+      - pacha_data:/app
+    ports:
+      - "5555:5000"
+
+volumes:
+  pacha_data:


### PR DESCRIPTION
to help running pacha faster locally, added a compose file. 

Using docker volume for sqlite storage, can modify to following to use local sqlite file

```yaml
version: '3.8'

services:
  pacha:
    build:
      context: .
      dockerfile: Dockerfile
    environment:
      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
      - SQL_URL=http://host.docker.internal:3001/v1/sql
      - PORT=5000
      - PACHA_LOG_LEVEL=debug
      - SECRET_KEY=secret
    volumes:
      - ./pacha.db:/app/pacha.db
    ports:
      - "5555:5000"
```