### PR TITLE
Tristen/fix origins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,4 +175,3 @@ examples/chat_server/.DS_Store
 examples/utils/.DS_Store
 eval/.DS_Store
 
-*.db

--- a/.gitignore
+++ b/.gitignore
@@ -176,3 +176,4 @@ examples/utils/.DS_Store
 eval/.DS_Store
 
 *.db
+

--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,4 @@ examples/chat_server/.DS_Store
 examples/utils/.DS_Store
 eval/.DS_Store
 
+*.db

--- a/.gitignore
+++ b/.gitignore
@@ -123,6 +123,7 @@ celerybeat.pid
 
 # Environments
 .env
+*.env
 .venv
 env/
 venv/
@@ -176,3 +177,4 @@ examples/utils/.DS_Store
 eval/.DS_Store
 
 *.db
+

--- a/.gitignore
+++ b/.gitignore
@@ -176,4 +176,3 @@ examples/utils/.DS_Store
 eval/.DS_Store
 
 *.db
-

--- a/.pacha.env.example
+++ b/.pacha.env.example
@@ -2,4 +2,6 @@ SQL_URL=http://local.hasura.dev:3000/v1/sql
 PORT=5001
 ANTHROPIC_API_KEY=sk-ant-key
 SECRET_KEY=secret_key
-ORIGIN="https://console.hasura.io"
+SQLITE_PATH=pacha.db
+CORS_ORIGINS="https://console.hasura.io"
+

--- a/.pacha.env.example
+++ b/.pacha.env.example
@@ -2,6 +2,4 @@ SQL_URL=http://local.hasura.dev:3000/v1/sql
 PORT=5001
 ANTHROPIC_API_KEY=sk-ant-key
 SECRET_KEY=secret_key
-SQLITE_PATH=pacha.db
 CORS_ORIGINS="https://console.hasura.io"
-

--- a/.pacha.env.example
+++ b/.pacha.env.example
@@ -1,0 +1,5 @@
+SQL_URL=http://local.hasura.dev:3000/v1/sql
+PORT=5001
+ANTHROPIC_API_KEY=sk-ant-key
+SECRET_KEY=secret_key
+ORIGIN="https://console.hasura.io"

--- a/compose.yaml
+++ b/compose.yaml
@@ -10,6 +10,5 @@ services:
     extra_hosts:
       - local.hasura.dev=host-gateway
     volumes:
-      - ./data/pacha.db:/app/pacha.db
-volumes:
-  data:
+    # NOTE: pacha.db must exist on host: `touch pacha.db` before running
+      - ./pacha.db:/app/pacha.db

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,15 @@
+services:
+  pacha:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    env_file:
+      - .pacha.env
+    ports:
+      - "5001:5001"
+    extra_hosts:
+      - local.hasura.dev=host-gateway
+    volumes:
+      - ./data/pacha.db:/app/pacha.db
+volumes:
+  data:

--- a/examples/chat_server/server.py
+++ b/examples/chat_server/server.py
@@ -31,7 +31,13 @@ SYSTEM_PROMPT: str = "You are a helpful assistant"
 DATABASE_PATH: str = "pacha.db"
 CORS_ORIGINS: List[str] = ["*"]
 
+
 app = FastAPI()
+
+# initialize cors
+origins = os.environ.get("CORS_ORIGINS", "*")
+CORS_ORIGINS = [origin.strip() for origin in origins.split(",")]
+
 
 # Enable CORS
 app.add_middleware(
@@ -314,10 +320,6 @@ async def async_setup():
     # initialize sqlite db
     DATABASE_PATH = os.environ.get("SQLITE_PATH", "pacha.db")
     await init_db(DATABASE_PATH)
-
-    # initialize cors
-    origins = os.environ.get("CORS_ORIGINS", "*")
-    CORS_ORIGINS = [origin.strip() for origin in origins.split(",")]
 
 
 def main():

--- a/examples/chat_server/server.py
+++ b/examples/chat_server/server.py
@@ -336,7 +336,7 @@ async def redirect_home():
     return RedirectResponse(url='/console')
 
 
-async def async_setup():
+async def async_setup(secret_key: str | None = None):
     global LLM
     global PACHA_TOOL
 
@@ -345,7 +345,7 @@ async def async_setup():
     add_llm_args(parser)
     add_tool_args(parser)
     args = parser.parse_args()
-    init_auth(args.secret_key)
+    init_auth(secret_key=secret_key)
     PACHA_TOOL = await get_pacha_tool(args, render_to_stdout=False)
     LLM = get_llm(args)
     init_system_prompt(PACHA_TOOL)
@@ -354,7 +354,8 @@ async def async_setup():
 
 def main():
     loop = asyncio.get_event_loop()
-    loop.run_until_complete(async_setup())
+    secret_key = os.environ.get("SECRET_KEY", None)
+    loop.run_until_complete(async_setup(secret_key=secret_key))
     log_level = os.environ.get('PACHA_LOG_LEVEL', 'INFO').upper()
     setup_logger(log_level)
     port = int(os.environ.get('PORT', 5000))

--- a/examples/chat_server/server.py
+++ b/examples/chat_server/server.py
@@ -27,7 +27,7 @@ app = FastAPI()
 # Enable CORS
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=[os.environ.get("ORIGIN", "*")], # Allow origin to be passed via env variable for deployment
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/examples/utils/cli.py
+++ b/examples/utils/cli.py
@@ -47,10 +47,6 @@ def add_tool_args(parser: argparse.ArgumentParser):
                         choices=['nl', 'sql', 'python'], default='python')
 
 
-def add_auth_args(parser: argparse.ArgumentParser):
-    parser.add_argument('-k', '--secret-key', type=str)
-
-
 async def get_pacha_tool(args, render_to_stdout=True) -> Tool:
     data_engine = get_data_engine(args)
     if args.tool == 'nl':


### PR DESCRIPTION
When deploying into digital ocean there is a CORS error because you can't use allow_origins=["*"] with allow_credentials=True. To fix this I have added an environment variable for origin which defaults to "*".

I also have setup a blank .db file so that when cloning this repo a directory won't be created when configuring the volume mount.

There is also an added compose.yaml file

I also provided a template .env in the .env.pacha.example